### PR TITLE
Upgrade PyInstaller to 6.16.0 to address CVE-2026-25990

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy==2.2.5
 pillow==11.3.0
 pydub==0.25.1
 pygame==2.6.1
-pyinstaller==6.13.0
+pyinstaller==6.16.0


### PR DESCRIPTION
### Motivation
- Remediate CVE-2026-25990 by upgrading the vulnerable PyInstaller dependency.

### Description
- Updated `requirements.txt` to pin `pyinstaller` from `6.13.0` to `6.16.0` with no application code changes.

### Testing
- Ran `python -m compileall main.py src` and the project sources compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd1de1e1883288d6608ba664025e6)